### PR TITLE
fix: sign_func 参数名不匹配导致签名失败

### DIFF
--- a/scripts/publish_xhs.py
+++ b/scripts/publish_xhs.py
@@ -138,9 +138,9 @@ class LocalPublisher:
         cookies = parse_cookie(self.cookie)
         a1 = cookies.get('a1', '')
         
-        def sign_func(uri, data=None, a1_param="", web_session=""):
-            # 使用 cookie 中的 a1 值
-            return local_sign(uri, data, a1=a1 or a1_param)
+        def sign_func(uri, data=None, a1="", web_session=""):
+            # XhsClient 调用时传入 a1= 和 web_session=，参数名必须匹配
+            return local_sign(uri, data, a1=a1)
         
         self.client = XhsClient(cookie=self.cookie, sign=sign_func)
         


### PR DESCRIPTION
## 修复内容

修复 `publish_xhs.py` 中 `sign_func` 函数的参数名不匹配问题。

### 问题
`XhsClient` 调用 `sign_func` 时传入 `a1=...` 参数，但原函数参数名为 `a1_param`，导致 TypeError:
```
sign_func() got an unexpected keyword argument 'a1'
```

### 修复
- 将参数名 `a1_param` 改为 `a1`，使其与 `XhsClient` 调用时的参数名一致
- 同时移除无用的 `web_session` 参数（`local_sign` 不需要）

### 影响的代码位置
`scripts/publish_xhs.py:141-143`

---

### Diff
```diff
-        def sign_func(uri, data=None, a1_param="", web_session=""):
-            # 使用 cookie 中的 a1 值
-            return local_sign(uri, data, a1=a1 or a1_param)
+        def sign_func(uri, data=None, a1="", web_session=""):
+            # XhsClient 调用时传入 a1= 和 web_session=，参数名必须匹配
+            return local_sign(uri, data, a1=a1)
```