### PR TITLE
fix: inline code block overflow

### DIFF
--- a/scripts/render_xhs.py
+++ b/scripts/render_xhs.py
@@ -398,7 +398,12 @@ def generate_card_html(content: str, theme: str, page_number: int = 1,
         }}
         
         {theme_css}
-        
+
+        .card-content :not(pre) > code {{
+            overflow-wrap: anywhere;
+            word-break: break-word;
+        }}
+
         .page-number {{
             position: absolute;
             bottom: 80px;
@@ -563,7 +568,7 @@ async def auto_split_content(body: str, theme: str, width: int, height: int,
                 
                 # 内容区域的可用高度（去除 padding 等）
                 available_height = height - 220  # 50*2 padding + 60*2 inner padding
-                
+
                 if content_height > available_height and current_content:
                     # 当前卡片已满，保存并开始新卡片
                     cards.append('\n\n'.join(current_content))


### PR DESCRIPTION
## 概述
修复小红书卡片渲染中行内代码块（inline code）内容溢出的问题。                                                                      

## 问题                                                                                                                       
  当行内代码块包含长文本或长单词时，内容会溢出，导致显示不完整或破坏布局。                                                       
<img width="2160" height="2880" alt="bug_pic_1" src="https://github.com/user-attachments/assets/dd6390df-2570-4e8a-b983-aafc7407d052" />

## 解决方案
  为非 `<pre>` 标签内的 `<code>` 元素添加 CSS 样式：
- `overflow-wrap: anywhere` - 允许在任意字符处换行
- `word-break: break-word` - 确保长单词可以被打断换行
<img width="2160" height="2880" alt="card_1" src="https://github.com/user-attachments/assets/a7ea73b9-68f4-47db-b082-cbcb71e1146f" />

## 修改文件
- `scripts/render_xhs.py:401-404` - 在主题样式中添加行内代码块溢出处理                                                                                                                                 